### PR TITLE
fix: Knowledge hub to redirect to the hub #2

### DIFF
--- a/src/pages/Landing/TutorialTips.tsx
+++ b/src/pages/Landing/TutorialTips.tsx
@@ -355,7 +355,7 @@ export function TutorialTips () {
             <div>
               <Button
                 leftIcon={<MonitorPlay size={24} weight={'duotone'}/>}
-                href={`https://discuss.logseq.com/`}
+                href={`https://hub.logseq.com/`}
                 className={'w-full sm:w-auto'}
               >
                 Knowledge Hub


### PR DESCRIPTION
closes #2

This change makes more logical sense to me, especially as there already is a link to the forum next to it. 