### PR TITLE
Fix header spacing and background on downloads

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -17,7 +17,7 @@ body {
 .ani-slide-in-from-bottom {
   /* @apply animate-in fade-in-0 duration-1000 slide-in-from-bottom-14; */
   @apply animate-in fade-in-0 slide-in-from-bottom-14;
-  animation-duration: 1s;
+  animation-duration: 2s;
 
   visibility: visible !important;
 }
@@ -131,11 +131,12 @@ body {
 
     &.is-active {
       .right-group-inner {
-        @apply visible flex opacity-100 z-40;
+        @apply visible flex opacity-100 z-40 bg-logseq-800 sm:bg-logseq-800/0;
       }
 
       &:before {
-        display: block;
+        @apply block sm:hidden;
+        /* display: block; */
       }
     }
   }

--- a/src/pages/Downloads/index.tsx
+++ b/src/pages/Downloads/index.tsx
@@ -481,7 +481,7 @@ export function HeadDownloadLinks () {
 
 export function DownloadsPage () {
   return (
-    <div className="app-page">
+    <div className="app-page pt-20">
       <div className="page-inner-full-wrap dl-a">
         <div className="page-inner">
           <HeadDownloadLinks/>


### PR DESCRIPTION
Fixed some issues reported by @tiensonqin:

- Downloads page does not have the required top padding to compensate for fixed header
- Mobile menu drawers background is now missing
- Resizing the window above the `sm` breakpoint while the mobile menu drawer is open causes a black overlay to persist