### PR TITLE
fix: z-index of buttons

### DIFF
--- a/src/pages/Landing/HeadShowcase.tsx
+++ b/src/pages/Landing/HeadShowcase.tsx
@@ -175,7 +175,7 @@ export function HeadShowcase () {
           </div>
 
           {/*  action buttons */}
-          <div className="actions-4 z-30">
+          <div className="relative actions-4 z-30">
             <WrapGlobalDownloadButton
               className="is-super-button"
             >


### PR DESCRIPTION
The background image has a `z-10` class and the buttons wrapper has `z-30`. The problem is that the image is absolute positioned and absolute/relative/fixed elements use a different z-index stack on top of the statically positioned elements. Adding the relative class should make the top half of those buttons clickable.

![Screenshot from 2023-01-30 21-11-10](https://user-images.githubusercontent.com/10744960/215580344-311e1f32-f5ac-4107-9da7-53f297b48907.png)
