### PR TITLE
perf(a11y): improve accessibility experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport"
-        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+        content="width=device-width, initial-scale=1.0, maximum-scale=5.0, minimum-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Logseq: A privacy-first, open-source knowledge base</title>
   <link href="https://asset.logseq.com/static/img/logo.png" rel="shortcut icon" type="image/png">

--- a/src/components/Headbar.tsx
+++ b/src/components/Headbar.tsx
@@ -106,7 +106,7 @@ export function Headbar () {
     <div className={'app-headbar h-14 flex justify-center'}>
       <div className={'flex items-center justify-between w-full'}>
         <div className={'flex items-center h-full flex-1'}>
-          <Link to={'/'} className={'app-logo-link mr-2'}></Link>
+          <Link to={'/'} className={'app-logo-link mr-2'} aria-label={`Logseq's logo`}></Link>
 
           <LinksGroup
             className={'justify-center sm:justify-start'}

--- a/src/components/Headbar.tsx
+++ b/src/components/Headbar.tsx
@@ -135,7 +135,7 @@ export function Headbar () {
 
                   return (
                     <a
-                      className={'flex items-center bg-sky-600 px-2 py-1 rounded text-sm hover:opacity-80 select-none cursor-pointer'}>
+                      className={'flex items-center bg-sky-700 px-2 py-1 rounded text-sm hover:opacity-80 select-none cursor-pointer'}>
                       {typeof leftIconFn === 'function'
                         ? leftIconFn({ weight: 'bold' })
                         : leftIconFn}

--- a/src/pages/Landing/DailyShowcase.tsx
+++ b/src/pages/Landing/DailyShowcase.tsx
@@ -137,6 +137,7 @@ export function DailyShowcaseSelect(
                   )
                 }}
                 value={activeShowcase}
+                aria-label="Select your use case"
         >
           {showcases.map(it => {
             return (
@@ -314,7 +315,7 @@ export function DailyShowcase() {
                               className="opacity-60">Twitter</span></>)}
                           <span
                             className="border rounded p-1 border-gray-600 ml-3 bg-gray-500/20 cursor-pointer active:opacity-80">
-                            <a target={'_blank'} href={it.refLink}>
+                            <a target={'_blank'} href={it.refLink} aria-label={`${it.userName}'s comment in ${it.refType}`}>
                               <ArrowSquareOut size={18} weight={'duotone'}/>
                             </a>
                           </span>

--- a/src/pages/Landing/DailyShowcase.tsx
+++ b/src/pages/Landing/DailyShowcase.tsx
@@ -20,7 +20,7 @@ const showcases = [
     refType: 'discord',
     desc: (
       <p>
-        Communicate better. <span className="opacity-60">Stay on top of your <br/>relationships, conversations, and meetings.</span>
+        Communicate better. <span className="opacity-70">Stay on top of your <br/>relationships, conversations, and meetings.</span>
       </p>),
     feedback: (
       <p>

--- a/src/pages/Landing/LandingFooterNav.tsx
+++ b/src/pages/Landing/LandingFooterNav.tsx
@@ -236,10 +236,10 @@ export function LandingFooterDesc (props: {
         </h1>
 
         <h2 className="text-lg mt-2 sm:mt-0 sm:text-3xl sm:text-center sm:tracking-wide">
-          <strong className="opacity-50 font-normal">By thinking and writing with Logseq, you'll </strong><br/>
+          <strong className="opacity-70 font-normal">By thinking and writing with Logseq, you'll </strong><br/>
           <span className="">gain confidence in what you know and <br/>
             stop worrying about forgetting </span>
-          <strong className={'opacity-50 font-normal'}>anything</strong>.
+          <strong className="opacity-70 font-normal">anything</strong>.
         </h2>
 
         <div className="actions-4 sm:flex sm:space-x-4 pt-10 pb-1">

--- a/src/pages/Landing/TutorialShowcase.tsx
+++ b/src/pages/Landing/TutorialShowcase.tsx
@@ -324,6 +324,7 @@ export function TutorialFeaturesSelect () {
                   )
                 }}
                 value={activeIndex}
+                aria-label="Select your role"
         >
           {featuresSlideItems.map((it, idx) => {
             return (<option

--- a/src/pages/Landing/TutorialTips.tsx
+++ b/src/pages/Landing/TutorialTips.tsx
@@ -144,7 +144,7 @@ export function TipSlideItem (props: {
           return (
             <span className={'animate-in duration-1000 fade-in-0'} key={idx}>
               <strong>Tip {idx + 1}: </strong>
-              <span className="text-gray-300/70">{it}</span>
+              <span className="text-gray-300/90">{it}</span>
             </span>
           )
         })}
@@ -395,7 +395,7 @@ export function TutorialTips () {
           <div className="sm:flex sm:space-x-6 py-5">
             <div className="flex flex-col space-x-2">
               <Button
-                className="bg-[#7289da] px-4 sm:px-8"
+                className="bg-[#5865F2]/75 px-4 sm:px-8"
                 leftIcon={<DiscordLogo size={20} weight={'duotone'}/>}
                 rightIcon={<SignIn className="opacity-40" size={20} weight={'duotone'}/>}
                 href={`https://discord.gg/VNfUaTtdFb`}

--- a/src/pages/Landing/index.css
+++ b/src/pages/Landing/index.css
@@ -693,7 +693,7 @@ h1, h2, h3 {
             @apply flex items-center py-2;
 
             button {
-              @apply py-2 px-5 font-bold opacity-80 text-gray-300/60 uppercase;
+              @apply py-2 px-5 font-bold opacity-80 text-gray-200 uppercase;
             }
           }
 


### PR DESCRIPTION
The background color of the Discord button was changed from `#7289da` to [the officially announced `#5865F2`](https://discord.com/branding), with minor adjustments to match the design.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>

  <tr>
    <td>
<img width="116" alt="image" src="https://user-images.githubusercontent.com/45708948/216663912-dc76f7ef-9643-4cd8-a834-2e5784fd2feb.png">
</td>
    <td>
<img width="102" alt="image" src="https://user-images.githubusercontent.com/45708948/216663559-cc2239c5-d458-43eb-90f6-05b0f030a216.png">
</td>
  </tr>
  <tr>
    <th colspan="2">Google Lighthouse Accessibility Score</th>
  </tr>
</table>

---

The `aria-label` is something I wrote based on my own ideas, and reviewers need to pay attention to whether it meets Logseq requirements.