### PR TITLE
fix not downloading arm64 when clicked #15

### DIFF
--- a/src/pages/Downloads/index.tsx
+++ b/src/pages/Downloads/index.tsx
@@ -193,7 +193,7 @@ export function WrapGlobalDownloadButton (
           <div
             className={'w-full flex flex-col opacity-80'}
             onClick={(e) => {
-              downloadHandler(appState, active, isIOS, 'macos-x64')
+              downloadHandler(appState, active, isIOS, 'macos-arm64')
             }}
           >
             <span className="text-sm">


### PR DESCRIPTION
fixes #15

Small typo caused the intel version to be downloaded instead of the arm64 version even when the Apple Silicon option was clicked