### PR TITLE
Fix advice for choosing Intel Mac download

### DIFF
--- a/src/pages/Downloads/index.tsx
+++ b/src/pages/Downloads/index.tsx
@@ -177,7 +177,7 @@ export function WrapGlobalDownloadButton (
               Intel chip
             </span>
               <span className="text-[11px] opacity-60">
-              Most common in Macs
+              Macs from before November 2020
             </span>
             </div>
           </div>


### PR DESCRIPTION
Given that the upcoming macOS 27 drops support for intel macs, I think it is not true now that Intel Macs are more common than Apple Silicon.