### PR TITLE
Update Mac compatibility text for Apple silicon

### DIFF
--- a/src/pages/Downloads/index.tsx
+++ b/src/pages/Downloads/index.tsx
@@ -177,7 +177,7 @@ export function WrapGlobalDownloadButton (
               Apple silicon (ARM)
             </span>
               <span className="text-[11px] opacity-60">
-              Macs from before November 2020
+              Macs after 2020 with Apple M processors
             </span>
             </div>
           </div>

--- a/src/pages/Downloads/index.tsx
+++ b/src/pages/Downloads/index.tsx
@@ -177,7 +177,7 @@ export function WrapGlobalDownloadButton (
               Apple silicon (ARM)
             </span>
               <span className="text-[11px] opacity-60">
-              Macs after 2020 with Apple M processors
+              Macs after November 2020
             </span>
             </div>
           </div>


### PR DESCRIPTION
When #41 and #42 were merged, they conflicted in a way that made the resulting text incorrect (stating Apple silicon processors were before Nov 2020). This fixes the issue.