### PR TITLE
Fix Apple silicon download description wording

### DIFF
--- a/src/pages/Downloads/index.tsx
+++ b/src/pages/Downloads/index.tsx
@@ -177,7 +177,7 @@ export function WrapGlobalDownloadButton (
               Apple silicon (ARM)
             </span>
               <span className="text-[11px] opacity-60">
-              Macs from before November 2020
+              Macs from after November 2020
             </span>
             </div>
           </div>

--- a/src/pages/Downloads/index.tsx
+++ b/src/pages/Downloads/index.tsx
@@ -177,7 +177,7 @@ export function WrapGlobalDownloadButton (
               Apple silicon (ARM)
             </span>
               <span className="text-[11px] opacity-60">
-              Macs from after November 2020
+              Macs after November 2020
             </span>
             </div>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Corrects the Apple silicon (ARM) download dropdown copy from "Macs from before November 2020" to "Macs after November 2020" on the Downloads page.

## Test plan
- [ ] Open logseq.com downloads / MacOS dropdown and confirm Apple silicon description says "Macs after November 2020"
- [ ] Confirm Intel option text is unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04d55-77da-742a-878a-242dc3892160?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04d55-77da-742a-878a-242dc3892160&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

